### PR TITLE
Normalise the entire prefix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Build
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Publish plugin
 
 on:
   push:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ gradlePlugin {
   // Define the plugin
   val ideaExt by plugins.creating {
     id = "uk.org.lidalia.ideaext"
-    version = "0.2.0"
+    version = "0.3.0"
     implementationClass = "uk.org.lidalia.gradle.plugin.ideaext.LidaliaIdeaExtPlugin"
   }
 }

--- a/src/functionalTest/kotlin/LidaliaIdeaExtPluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/LidaliaIdeaExtPluginFunctionalTest.kt
@@ -26,17 +26,14 @@ class LidaliaIdeaExtPluginFunctionalTest : StringSpec({
     @Language("kotlin")
     val buildFile = """
       plugins {
-//        kotlin("jvm") version "1.7.22"
         id("uk.org.lidalia.ideaext")
       }
-      
+
       idea {
         setPackagePrefix("com.example.foo")
       }
     """.trimIndent()
-    getBuildFile().writeText(
-      buildFile,
-    )
+    getBuildFile().writeText(buildFile)
 
     // Run the build
     val result = GradleRunner.create()

--- a/src/main/kotlin/IdeaModelExtensions.kt
+++ b/src/main/kotlin/IdeaModelExtensions.kt
@@ -3,6 +3,7 @@
 package uk.org.lidalia.gradle.plugin.ideaext.ideamodelextensions
 
 import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.gradle.plugins.ide.idea.model.IdeaModule
 import org.jetbrains.gradle.ext.ModuleSettings
@@ -16,3 +17,5 @@ internal val IdeaModule.moduleSettings: ModuleSettings get() = getExtensionByTyp
 
 internal val ModuleSettings.packagePrefixContainer: PackagePrefixContainer
   get() = getExtensionByType()
+
+internal val IdeaModel.extensions get() = (this as ExtensionAware).extensions

--- a/src/main/kotlin/LidaliaIdeaExtPlugin.kt
+++ b/src/main/kotlin/LidaliaIdeaExtPlugin.kt
@@ -4,10 +4,10 @@ package uk.org.lidalia.gradle.plugin.ideaext
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.reflect.TypeOf
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.jetbrains.gradle.ext.IdeaExtPlugin
+import uk.org.lidalia.gradle.plugin.ideaext.ideamodelextensions.extensions
 import uk.org.lidalia.gradle.plugin.ideaext.ideamodelextensions.ideaModel
 import uk.org.lidalia.gradle.plugin.ideaext.ideamodelextensions.moduleSettings
 import uk.org.lidalia.gradle.plugin.ideaext.ideamodelextensions.packagePrefixContainer
@@ -19,13 +19,12 @@ class LidaliaIdeaExtPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.plugins.apply(IdeaExtPlugin::class.java)
     val ideaModel = project.ideaModel
-    val ideaModelExt = ideaModel as ExtensionAware
 
-    val defaultPackagePrefix = "${project.group}.${project.name.normalise()}"
+    val defaultPackagePrefix = "${project.group}.${project.name}".normalise()
 
     ideaModel.setPackagePrefix(defaultPackagePrefix)
 
-    ideaModelExt
+    ideaModel
       .extensions
       .add(
         object : TypeOf<Function1<String, Unit>>() {},
@@ -36,9 +35,9 @@ class LidaliaIdeaExtPlugin : Plugin<Project> {
   }
 }
 
-private val unwantedPackageChars = "[^a-z0-9]".toRegex()
+private val unwantedPackageChars = "[^a-z0-9.]".toRegex()
 
-private fun String.normalise() = this.toLowerCase().remove(unwantedPackageChars)
+private fun String.normalise() = this.lowercase().remove(unwantedPackageChars)
 
 private fun String.remove(regex: Regex) = replace(regex, "")
 


### PR DESCRIPTION
A gradle project group can contain characters that are not valid package names.
